### PR TITLE
minikit updates adjustments

### DIFF
--- a/demo/with-next/components/ClientContent/VerifyAction/index.tsx
+++ b/demo/with-next/components/ClientContent/VerifyAction/index.tsx
@@ -7,7 +7,8 @@ import {
 } from "@worldcoin/minikit-js";
 import { useCallback, useEffect, useState } from "react";
 import * as yup from "yup";
-import { validateSchema } from "./helpers/validate-schema";
+import { validateSchema } from "../helpers/validate-schema";
+import { verifyProof } from "./verify-cloud-proof";
 
 const verifyActionSuccessPayloadSchema = yup.object({
   status: yup
@@ -84,16 +85,16 @@ export const VerifyAction = () => {
         return console.log("lastUsedAppId or lastUsedAction is not set");
       }
 
-      const verifyResponse = await verifyCloudProof(
-        {
+      const verifyResponse = await verifyProof({
+        payload: {
           proof: payload.proof,
           merkle_root: payload.merkle_root,
           nullifier_hash: payload.nullifier_hash,
           verification_level: payload.verification_level,
         },
-        lastUsedAppId,
-        lastUsedAction
-      );
+        app_id: lastUsedAppId,
+        action: lastUsedAction,
+      });
 
       setDevPortalVerifyResponse(verifyResponse);
     });

--- a/demo/with-next/components/ClientContent/VerifyAction/verify-cloud-proof.ts
+++ b/demo/with-next/components/ClientContent/VerifyAction/verify-cloud-proof.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { IDKitConfig, ISuccessResult } from "@worldcoin/idkit-core";
+
+import {
+  IVerifyResponse,
+  verifyCloudProof,
+} from "@worldcoin/idkit-core/backend";
+
+export const verifyProof = async (params: {
+  app_id: IDKitConfig["app_id"];
+  action: string;
+  payload: ISuccessResult;
+}) => {
+  const { app_id, action, payload } = params;
+  let verifyResponse: IVerifyResponse | null = null;
+
+  try {
+    verifyResponse = await verifyCloudProof(
+      {
+        proof: payload.proof,
+        merkle_root: payload.merkle_root,
+        nullifier_hash: payload.nullifier_hash,
+        verification_level: payload.verification_level,
+      },
+      app_id,
+      action
+    );
+  } catch (error) {
+    console.log("Error in verifyCloudProof", error);
+  }
+
+  return verifyResponse;
+};

--- a/demo/with-next/package.json
+++ b/demo/with-next/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@worldcoin/idkit-core": "^1.2.0",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,9 +8,7 @@ interface Window {
   };
 
   Android?: {
-    minikit?: () => {
-      sendEvent: (payload: string) => void;
-    };
+    postMessage?: (payload: string) => void;
   };
 
   MiniKit?: import("./minikit").MiniKit;

--- a/src/helpers/send-webview-event.ts
+++ b/src/helpers/send-webview-event.ts
@@ -6,6 +6,6 @@ export const sendWebviewEvent = <
   if (window.webkit) {
     window.webkit?.messageHandlers?.minikit?.postMessage?.(payload);
   } else if (window.Android) {
-    window.Android.minikit?.()?.sendEvent?.(JSON.stringify(payload));
+    window.Android.postMessage?.(JSON.stringify(payload));
   }
 };

--- a/src/package.json
+++ b/src/package.json
@@ -28,7 +28,8 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint ./ --ext .ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@worldcoin/idkit-core": "^1.2.0"


### PR DESCRIPTION
- Updates interface for sending messages to Android.
- Adds `typecheck` script both to minikit and demo
- Moves dev portal verify proof logic to the server action, because `verifyCloudProof` can be called from the server only.