### PR TITLE
feat: Add username support

### DIFF
--- a/packages/core/helpers/usernames/index.ts
+++ b/packages/core/helpers/usernames/index.ts
@@ -1,0 +1,14 @@
+export const getUserProfile = async (address: string) => {
+  const res = await fetch('https://usernames.worldcoin.org/api/v1/query', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      addresses: [address]
+    })
+  })
+
+  const data = await res.json();
+  return data.usernames[0];
+};

--- a/packages/core/helpers/usernames/index.ts
+++ b/packages/core/helpers/usernames/index.ts
@@ -10,5 +10,5 @@ export const getUserProfile = async (address: string) => {
   })
 
   const data = await res.json();
-  return data.usernames[0];
+  return data.usernames[0] ?? { username: null, profilePictureUrl: null };
 };

--- a/packages/core/minikit.ts
+++ b/packages/core/minikit.ts
@@ -78,11 +78,7 @@ export class MiniKit {
     walletAddress: string | null;
     username: string | null;
     profilePictureUrl: string | null;
-  } = {
-    walletAddress: null,
-    username: null,
-    profilePictureUrl: null,
-  };
+  } | null = null;
 
   private static sendInit() {
     sendWebviewEvent({
@@ -105,9 +101,11 @@ export class MiniKit {
         if (payload.status === "success") {
           MiniKit.walletAddress = payload.address;
           getUserProfile(payload.address).then((queryResponse) => {
-            MiniKit.user.username = queryResponse.username;
-            MiniKit.user.profilePictureUrl = queryResponse.profilePictureUrl;
-            MiniKit.user.walletAddress = payload.address;
+            MiniKit.user = {
+              username: queryResponse.username,
+              profilePictureUrl: queryResponse.profilePictureUrl,
+              walletAddress: payload.address,
+            };
           });
         }
 

--- a/packages/core/minikit.ts
+++ b/packages/core/minikit.ts
@@ -32,6 +32,7 @@ import {
   MiniKitInstallErrorMessage,
 } from "types";
 import { validatePaymentPayload } from "helpers/payment/client";
+import { getUserProfile } from "helpers/usernames";
 
 export const sendMiniKitEvent = <
   T extends WebViewBasePayload = WebViewBasePayload,
@@ -73,6 +74,8 @@ export class MiniKit {
 
   public static appId: string | null = null;
   public static walletAddress: string | null = null;
+  public static username: string | null = null;
+  public static profilePictureUrl: string | null = null;
 
   private static sendInit() {
     sendWebviewEvent({
@@ -94,6 +97,10 @@ export class MiniKit {
       ) => {
         if (payload.status === "success") {
           MiniKit.walletAddress = payload.address;
+          getUserProfile(payload.address).then((queryResponse) => {
+            MiniKit.username = queryResponse.username;
+            MiniKit.profilePictureUrl = queryResponse.profilePictureUrl;
+          });
         }
 
         originalHandler(payload);

--- a/packages/core/minikit.ts
+++ b/packages/core/minikit.ts
@@ -74,8 +74,15 @@ export class MiniKit {
 
   public static appId: string | null = null;
   public static walletAddress: string | null = null;
-  public static username: string | null = null;
-  public static profilePictureUrl: string | null = null;
+  public static user: {
+    walletAddress: string | null;
+    username: string | null;
+    profilePictureUrl: string | null;
+  } = {
+    walletAddress: null,
+    username: null,
+    profilePictureUrl: null,
+  };
 
   private static sendInit() {
     sendWebviewEvent({
@@ -98,8 +105,9 @@ export class MiniKit {
         if (payload.status === "success") {
           MiniKit.walletAddress = payload.address;
           getUserProfile(payload.address).then((queryResponse) => {
-            MiniKit.username = queryResponse.username;
-            MiniKit.profilePictureUrl = queryResponse.profilePictureUrl;
+            MiniKit.user.username = queryResponse.username;
+            MiniKit.user.profilePictureUrl = queryResponse.profilePictureUrl;
+            MiniKit.user.walletAddress = payload.address;
           });
         }
 


### PR DESCRIPTION
When using Wallet Auth, adds `MiniKit.user.walletAddress`, `MiniKit.user.username`, and `MiniKit.user.profilePictureUrl` to the `MiniKit` object to make username functionality easier for Mini Apps.

`MiniKit.walletAddress` will be deprecated, I will update docs to reflect new user object.