### PR TITLE
fix: use default `GITHUB_TOKEN` for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           command: manifest
           release-type: node
-          token: ${{ secrets.GIT_HUB_TOKEN }}
 
       - name: Debug Output
         run: echo "Release Created - ${{ steps.release.outputs.release_created }}"


### PR DESCRIPTION
Attempt to fix release-please by using default `GITHUB_TOKEN` (to match `idkit-js` config)