### PR TITLE
feat: add transaction payload validation

### DIFF
--- a/packages/core/helpers/transaction/validate-payload.ts
+++ b/packages/core/helpers/transaction/validate-payload.ts
@@ -1,0 +1,20 @@
+import { SendTransactionInput } from "types/commands";
+type ValidationReturn = { isValid: true } | { isValid: false };
+
+const validate = (payload: any): ValidationReturn => {
+  if (typeof payload === "string") return { isValid: true };
+  if (typeof payload === "object") {
+    const isValid = Object.values(payload).every(
+      (value) => validate(value).isValid
+    );
+    return { isValid };
+  }
+  if (Array.isArray(payload)) {
+    const isValid = payload.every((value) => validate(value).isValid);
+    return { isValid };
+  }
+  return { isValid: false };
+};
+
+export const validateSendTransactionPayload = (payload: SendTransactionInput) =>
+  validate(payload);

--- a/packages/core/minikit.ts
+++ b/packages/core/minikit.ts
@@ -45,6 +45,7 @@ import {
 } from "types";
 import { validatePaymentPayload } from "helpers/payment/client";
 import { getUserProfile } from "helpers/usernames";
+import { validateSendTransactionPayload } from "helpers/transaction/validate-payload";
 
 export const sendMiniKitEvent = <
   T extends WebViewBasePayload = WebViewBasePayload,
@@ -387,6 +388,13 @@ export class MiniKit {
           "'sendTransaction' command is unavailable. Check MiniKit.install() or update the app version"
         );
 
+        return null;
+      }
+
+      if (!validateSendTransactionPayload(payload).isValid) {
+        console.error(
+          "Invalid sendTransaction payload - some object properties are not strings"
+        );
         return null;
       }
 

--- a/tests/validate-payload.test.js
+++ b/tests/validate-payload.test.js
@@ -1,0 +1,115 @@
+// import { validateSendTransactionPayload } from "@worldcoin/minikit-js/core/helpers/transaction/validate-transaction";
+const validate = (payload) => {
+  if (typeof payload === "string") return { isValid: true };
+  if (typeof payload === "object") {
+    const isValid = Object.values(payload).every(
+      (value) => validate(value).isValid
+    );
+    return { isValid };
+  }
+  if (Array.isArray(payload)) {
+    const isValid = payload.every((value) => validate(value).isValid);
+    return { isValid };
+  }
+  return { isValid: false };
+};
+
+export const validateSendTransactionPayload = (payload) => validate(payload);
+
+describe("validateSendTransactionPayload", () => {
+  it("should validate simple string values", () => {
+    const payload = {
+      transaction: [
+        {
+          address: "0x123",
+          functionName: "transfer",
+          args: ["0x456", "1000000000000000000"],
+        },
+      ],
+    };
+    expect(validateSendTransactionPayload(payload)).toMatchObject({
+      isValid: true,
+    });
+  });
+
+  it("should validate nested objects", () => {
+    const payload = {
+      transaction: [
+        {
+          address: "0x123",
+          abi: [
+            {
+              name: "transfer",
+              type: "function",
+              inputs: [
+                { name: "recipient", type: "address" },
+                { name: "amount", type: "uint256" },
+              ],
+            },
+          ],
+          functionName: "transfer",
+          args: ["0x456", "1000000000000000000"],
+        },
+      ],
+    };
+    expect(validateSendTransactionPayload(payload)).toMatchObject({
+      isValid: true,
+    });
+  });
+
+  it("should validate with permit2 data", () => {
+    const payload = {
+      transaction: [
+        {
+          address: "0x123",
+          functionName: "transfer",
+          args: ["0x456", "1000000000000000000"],
+        },
+      ],
+      permit2: [
+        {
+          permitted: {
+            token: "0x789",
+            amount: "1000000000000000000",
+          },
+          spender: "0xabc",
+          nonce: "1",
+          deadline: "1234567890",
+        },
+      ],
+    };
+    expect(validateSendTransactionPayload(payload)).toMatchObject({
+      isValid: true,
+    });
+  });
+
+  it("should reject invalid values like numbers", () => {
+    const payload = {
+      transaction: [
+        {
+          address: "0x123",
+          functionName: "transfer",
+          args: [123, "1000000000000000000"], // number instead of string
+        },
+      ],
+    };
+    expect(validateSendTransactionPayload(payload)).toMatchObject({
+      isValid: false,
+    });
+  });
+
+  it("should reject invalid values like booleans", () => {
+    const payload = {
+      transaction: [
+        {
+          address: "0x123",
+          functionName: "transfer",
+          args: [true, "1000000000000000000"], // boolean instead of string
+        },
+      ],
+    };
+    expect(validateSendTransactionPayload(payload)).toMatchObject({
+      isValid: false,
+    });
+  });
+});


### PR DESCRIPTION
ios would throw hard to track errors when `sendTransaction` was provided with non-string args - this should fix it