### PR TITLE
feat: expose method to fetch user details

### DIFF
--- a/packages/core/minikit.ts
+++ b/packages/core/minikit.ts
@@ -45,6 +45,7 @@ import {
 } from "types";
 import { validatePaymentPayload } from "helpers/payment/client";
 import { getUserProfile } from "helpers/usernames";
+import { User } from "./types/user";
 
 export const sendMiniKitEvent = <
   T extends WebViewBasePayload = WebViewBasePayload,
@@ -92,11 +93,7 @@ export class MiniKit {
    * @deprecated you should use MiniKit.user.walletAddress instead
    */
   public static walletAddress: string | null = null;
-  public static user: {
-    walletAddress: string | null;
-    username: string | null;
-    profilePictureUrl: string | null;
-  } | null = null;
+  public static user: User | null = null;
 
   private static sendInit() {
     sendWebviewEvent({
@@ -118,12 +115,8 @@ export class MiniKit {
       ) => {
         if (payload.status === "success") {
           MiniKit.walletAddress = payload.address;
-          getUserProfile(payload.address).then((queryResponse) => {
-            MiniKit.user = {
-              username: queryResponse.username,
-              profilePictureUrl: queryResponse.profilePictureUrl,
-              walletAddress: payload.address,
-            };
+          MiniKit.getUserByAddress(payload.address).then((user) => {
+            MiniKit.user = user;
           });
         }
 
@@ -258,6 +251,16 @@ export class MiniKit {
       );
     return isInstalled;
   }
+
+  public static getUserByAddress = async (address: string): Promise<User> => {
+    const userProfile = await getUserProfile(address);
+
+    return {
+      walletAddress: address,
+      username: userProfile.username,
+      profilePictureUrl: userProfile.profilePictureUrl,
+    };
+  };
 
   public static commands = {
     verify: (payload: VerifyCommandInput): VerifyCommandPayload | null => {

--- a/packages/core/types/user.ts
+++ b/packages/core/types/user.ts
@@ -1,0 +1,5 @@
+export type User = {
+    walletAddress: string;
+    username: string | null;
+    profilePictureUrl: string | null;
+  };

--- a/packages/core/types/user.ts
+++ b/packages/core/types/user.ts
@@ -1,5 +1,5 @@
 export type User = {
-    walletAddress: string;
-    username: string | null;
-    profilePictureUrl: string | null;
-  };
+  walletAddress: string;
+  username: string | null;
+  profilePictureUrl: string | null;
+};


### PR DESCRIPTION
# Motivation
This PR adds a method to fetch user details by wallet address, allowing more flexible MiniApp structures. 

Previously, developers depended on Minikit to update a user’s static property. 

Now, after retrieving the wallet address from the “connect wallet” payload, they can manage user data themselves—eliminating the dependency and increasing flexibility.