### PR TITLE
compress proof on MiniAppVerifyAction

### DIFF
--- a/packages/core/helpers/proof/index.ts
+++ b/packages/core/helpers/proof/index.ts
@@ -1,0 +1,40 @@
+import { compressProof } from 'semaphore-rs-bundler';
+import { decodeAbiParameters, encodeAbiParameters } from 'viem';
+
+export const compressAndPadProof = (proof: `0x${string}`) => {
+  // Decode the hex proof to array of 8 uints
+  const decodedProof = decodeAbiParameters(
+    [{ type: 'uint256[8]' }],
+    proof,
+  )[0] as readonly [
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+  ];
+
+  // Convert to hex strings for compression
+  const proofHexStrings = [...decodedProof].map(
+    (p) => '0x' + p.toString(16).padStart(64, '0'),
+  ) as [string, string, string, string, string, string, string, string];
+
+  // Compress and pad the proof
+  const compressedProof = compressProof(proofHexStrings);
+  const paddedProof = [...compressedProof.map(BigInt), 0n, 0n, 0n, 0n] as [
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+  ];
+
+  // Encode back to hex string
+  return encodeAbiParameters([{ type: 'uint256[8]' }], [paddedProof]);
+};

--- a/packages/core/helpers/proof/index.ts
+++ b/packages/core/helpers/proof/index.ts
@@ -1,4 +1,4 @@
-import { compressProof } from 'semaphore-rs-bundler';
+import { compressProof } from 'semaphore-rs-js';
 import { decodeAbiParameters, encodeAbiParameters } from 'viem';
 
 export const compressAndPadProof = (proof: `0x${string}`) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "@worldcoin/idkit-core": "^1.3.0",
-    "abitype": "^1.0.6"
+    "abitype": "^1.0.6",
+    "semaphore-rs-bundler": "^0.1.4"
   },
   "description": "minikit-js is our SDK for building mini-apps.",
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@worldcoin/idkit-core": "^1.3.0",
     "abitype": "^1.0.6",
-    "semaphore-rs-bundler": "^0.1.4"
+    "semaphore-rs-js": "^0.3.0"
   },
   "description": "minikit-js is our SDK for building mini-apps.",
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,9 @@ importers:
       abitype:
         specifier: ^1.0.6
         version: 1.0.6(typescript@5.5.4)
-      semaphore-rs-bundler:
-        specifier: ^0.1.4
-        version: 0.1.4
+      semaphore-rs-js:
+        specifier: ^0.3.0
+        version: 0.3.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -2923,8 +2923,8 @@ packages:
   scrypt-js@3.0.1:
     resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
 
-  semaphore-rs-bundler@0.1.4:
-    resolution: {integrity: sha512-+UZkwfHS+1IxVuPMXNppkZUwLJXGTRujlFFXc/GMTBbPdyWhlO7RcsQC7mF/r+9jOnkJ1i2gSfX3AX13BaIdhw==}
+  semaphore-rs-js@0.3.0:
+    resolution: {integrity: sha512-+RbHspjjR7S+34H8u25dlLryhxdqd0DOoPFL/U8g/AB03jyJOtQCofmROiEYjy83gkJp7h2Lgbf12H71YBfIoQ==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5275,7 +5275,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -5306,7 +5306,7 @@ snapshots:
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -5324,7 +5324,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -6830,7 +6830,7 @@ snapshots:
 
   scrypt-js@3.0.1: {}
 
-  semaphore-rs-bundler@0.1.4: {}
+  semaphore-rs-js@0.3.0: {}
 
   semver@6.3.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       abitype:
         specifier: ^1.0.6
         version: 1.0.6(typescript@5.5.4)
+      semaphore-rs-bundler:
+        specifier: ^0.1.4
+        version: 0.1.4
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -2919,6 +2922,9 @@ packages:
 
   scrypt-js@3.0.1:
     resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
+
+  semaphore-rs-bundler@0.1.4:
+    resolution: {integrity: sha512-+UZkwfHS+1IxVuPMXNppkZUwLJXGTRujlFFXc/GMTBbPdyWhlO7RcsQC7mF/r+9jOnkJ1i2gSfX3AX13BaIdhw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -6823,6 +6829,8 @@ snapshots:
       loose-envify: 1.4.0
 
   scrypt-js@3.0.1: {}
+
+  semaphore-rs-bundler@0.1.4: {}
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
## PR Type

- [ x ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

We want to compress all proofs before returning to the user to save on calldata. This change is backwards compatible with the on-chain contracts that verify the proof. They look if the last 4 uints of the proof are 0s and will use the correct `verifyCompressedProof` function on the verifier instead. 