### PR TITLE
Username API returns profile picture URL in variable profile_picture_url

### DIFF
--- a/packages/core/helpers/usernames/index.ts
+++ b/packages/core/helpers/usernames/index.ts
@@ -10,5 +10,5 @@ export const getUserProfile = async (address: string) => {
   });
 
   const usernames = await res.json();
-  return usernames?.[0] ?? { username: null, profilePictureUrl: null };
+  return usernames?.[0] ?? { username: null, profile_picture_url: null };
 };

--- a/packages/core/minikit.ts
+++ b/packages/core/minikit.ts
@@ -298,7 +298,7 @@ export class MiniKit {
     return {
       walletAddress: address,
       username: userProfile.username,
-      profilePictureUrl: userProfile.profilePictureUrl,
+      profilePictureUrl: userProfile.profile_picture_url,
     };
   };
 


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

Username API (called by getUserProfile) returns the following schema:
```json
  {
    "address": "…",
    "profile_picture_url": null,
    "username": "…"
  }
```
However, a wrong variable *profilePictureUrl* is used instead.

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
