### PR TITLE
fix: minikit providers was always setting `isInstalled` to `true`

### DIFF
--- a/packages/core/minikit-provider.tsx
+++ b/packages/core/minikit-provider.tsx
@@ -24,10 +24,12 @@ export const MiniKitProvider = ({
   children: ReactNode;
   props?: MiniKitProps;
 }) => {
-  const [isInstalled, setIsInstalled] = useState(false);
+  const [isInstalled, setIsInstalled] = useState<boolean | undefined>(undefined);
 
   useEffect(() => {
-    MiniKit.install(props?.appId);
+    const { success } = MiniKit.install(props?.appId);
+    if (!success) return setIsInstalled(false);
+
     MiniKit.commandsAsync
       .getPermissions()
       .then(({ commandPayload: _, finalPayload }) => {


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [X] Bug Fix
- [ ] QA Tests

## Description
`MiniKitProvider` was always returning `true` on `isInstalled` state. I'm basically taking into consideration the returned `success` value from `MiniKit.install()` command.

I also changed `isInstalled` type to `boolean | undefined`. So, at the startup, `isInstalled` will be `undefined`, since installation process is actually in progress.

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
