### PR TITLE
fix : typo of USDC from USDCE in token

### DIFF
--- a/demo/next-15-template/src/components/Pay/index.tsx
+++ b/demo/next-15-template/src/components/Pay/index.tsx
@@ -32,8 +32,8 @@ export const Pay = () => {
           token_amount: tokenToDecimals(0.5, Tokens.WLD).toString(),
         },
         {
-          symbol: Tokens.USDCE,
-          token_amount: tokenToDecimals(0.1, Tokens.USDCE).toString(),
+          symbol: Tokens.USDC,
+          token_amount: tokenToDecimals(0.1, Tokens.USDC).toString(),
         },
       ],
       description: 'Test example payment for minikit',


### PR DESCRIPTION
Replace USDCE with USDC in payment tokens

## PR Type

- [ ] Bug Fix

## Description

Fixed a typo in the starter kit in Next15 template where it reference Tokens enums for USDCE. I faced this error while building the app this during the Ethglobal BA. 

It has enum but still targets this. 

```declare enum Tokens {
    USDC = "USDCE",
    WLD = "WLD"
}```

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
