### PR TITLE
fix: only specify pnpm version on package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0 (https://github.com/pnpm/action-setup/releases/tag/v4.2.0)
-        with:
-          version: 9.12.1
 
       - name: Install Dependencies
         run: pnpm install


### PR DESCRIPTION
Fixes this bug https://github.com/worldcoin/minikit-js/actions/runs/19771022577/job/56654959841