### PR TITLE
fix: Add missing permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: write
+  pull-requests: write 
   attestations: write
   id-token: write
 


### PR DESCRIPTION
Add pull-requests: write permission to fix release workflow.

  Problem

  PR #324 added explicit permissions for trusted publishing but omitted pull-requests: write. When permissions are explicitly defined, GitHub restricts the token to only those listed—breaking the changesets action's ability to create release PRs.