### PR TITLE
fix: Fix trusted publishing 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,5 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          NPM_TOKEN: '' # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
+


### PR DESCRIPTION
Reverts worldcoin/minikit-js#333

See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868