### PR TITLE
force update npm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,15 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0 (https://github.com/actions/setup-node/releases/tag/v6.0.0)
         with:
           node-version: 22.x
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Update npm for OIDC trusted publishing
+        run: |
+          # npm trusted publishing requires npm >= 11.5.1
+          # Node.js 22.x ships with npm 10.x, so we need to update
+          echo "Current npm version: $(npm --version)"
+          npm install -g npm@latest
+          echo "Updated npm version: $(npm --version)"
 
       - name: Setup PNPM
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0 (https://github.com/pnpm/action-setup/releases/tag/v4.2.0)


### PR DESCRIPTION
Following this thread: https://github.com/changesets/changesets/issues/1152

I've found 2 things that could fix broken release pipeline:
1. Defining `registry-url` in the setup node action
2. Upgrading npm to latest because Node 22.x ships with npm 10.x which doesn't include the latest patch

https://github.com/changesets/changesets/issues/1152