### PR TITLE
feat: update release workflow to use `ubuntu-latest` runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on:
-      group: arc-public-large-amd64-runner
+    runs-on: ubuntu-latest
     environment: production
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Publishing new version is failing https://github.com/worldcoin/minikit-js/actions/runs/21857275661/job/63085655226
```bash
🦋  error npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=936948604
🦋  error npm error code E422
🦋  error npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@worldcoin%2fminikit-js - Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.
🦋  error npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-02-10T09_47_57_686Z-debug-0.log
🦋  error 
🦋  error packages failed to publish:
🦋  @worldcoin/minikit-js@1.9.10
🦋  @worldcoin/minikit-react@1.9.11
```

Switching to a GitHub-hosted runner: change runs-on from the self-hosted runner group to a GitHub-hosted one like ubuntu-latest. This is the simplest fix.