### PR TITLE
feat: deprecate signTypedData

### DIFF
--- a/packages/core/commands/index.ts
+++ b/packages/core/commands/index.ts
@@ -65,6 +65,7 @@ export function createCommands(ctx: CommandContext) {
     walletAuth: createWalletAuthCommand(ctx),
     sendTransaction: createSendTransactionCommand(ctx),
     signMessage: createSignMessageCommand(ctx),
+    /** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
     signTypedData: createSignTypedDataCommand(ctx),
     shareContacts: createShareContactsCommand(ctx),
     requestPermission: createRequestPermissionCommand(ctx),
@@ -87,6 +88,7 @@ export function createAsyncCommands(ctx: CommandContext, commands: Commands) {
       commands.sendTransaction,
     ),
     signMessage: createSignMessageAsyncCommand(ctx, commands.signMessage),
+    /** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
     signTypedData: createSignTypedDataAsyncCommand(ctx, commands.signTypedData),
     shareContacts: createShareContactsAsyncCommand(ctx, commands.shareContacts),
     requestPermission: createRequestPermissionAsyncCommand(

--- a/packages/core/commands/sign-typed-data.ts
+++ b/packages/core/commands/sign-typed-data.ts
@@ -15,6 +15,7 @@ import {
 // Types
 // ============================================================================
 
+/** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
 export type SignTypedDataInput = {
   types: TypedData;
   primaryType: string;
@@ -23,8 +24,10 @@ export type SignTypedDataInput = {
   chainId?: number;
 };
 
+/** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
 export type SignTypedDataPayload = SignTypedDataInput;
 
+/** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
 export enum SignTypedDataErrorCodes {
   InvalidOperation = 'invalid_operation',
   UserRejected = 'user_rejected',
@@ -36,6 +39,7 @@ export enum SignTypedDataErrorCodes {
   MaliciousOperation = 'malicious_operation',
 }
 
+/** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
 export const SignTypedDataErrorMessage = {
   [SignTypedDataErrorCodes.InvalidOperation]:
     'Transaction included an operation that was invalid',
@@ -53,16 +57,19 @@ export const SignTypedDataErrorMessage = {
     'The operation requested is considered malicious.',
 };
 
+/** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
 export type MiniAppSignTypedDataSuccessPayload = MiniAppBaseSuccessPayload & {
   signature: string;
   address: string;
 };
 
+/** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
 export type MiniAppSignTypedDataErrorPayload =
   MiniAppBaseErrorPayload<SignTypedDataErrorCodes> & {
     details?: Record<string, any>;
   };
 
+/** @deprecated EIP-712 typed data signing is deprecated. Use signMessage or sendTransaction instead. */
 export type MiniAppSignTypedDataPayload =
   | MiniAppSignTypedDataSuccessPayload
   | MiniAppSignTypedDataErrorPayload;
@@ -73,6 +80,10 @@ export type MiniAppSignTypedDataPayload =
 
 export function createSignTypedDataCommand(_ctx: CommandContext) {
   return (payload: SignTypedDataInput): SignTypedDataPayload | null => {
+    console.warn(
+      'signTypedData is deprecated. Use signMessage or sendTransaction instead.',
+    );
+
     if (
       typeof window === 'undefined' ||
       !isCommandAvailable(Command.SignTypedData)


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Tag `signTypedData` as deprecated.

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
