### PR TITLE
fix(template): use published minikit dependencies

### DIFF
--- a/demo/next-15-template/.env.sample
+++ b/demo/next-15-template/.env.sample
@@ -1,6 +1,7 @@
-AUTH_SECRET="" # Added by `npx auth secret`. Read more: https://cli.authjs.dev
+AUTH_SECRET="" # Set to a secure random value. Read more: https://authjs.dev/getting-started/deployment
+AUTH_TRUST_HOST=true # Local/proxy testing only; remove in production unless your host/proxy is trusted
 HMAC_SECRET_KEY='some-secret' # create this by running `openssl rand -base64 32`
-AUTH_URL='' # For testing this should be your NGROK URL and for production this should be your production URL
+AUTH_URL='' # Set to your ngrok URL for testing or your production URL after deploy
 NEXT_PUBLIC_APP_ID='app_1234567890' # APP ID from the developer portal
 RP_SIGNING_KEY='' # RP signing key from the Developer Portal (IDKit / Relying Party)
 RP_ID='' # Your relying party id

--- a/demo/next-15-template/README.md
+++ b/demo/next-15-template/README.md
@@ -6,15 +6,14 @@ This template is a way for you to quickly get started with authentication and ex
 
 ## Getting Started
 
-1. cp .env.example .env.local
+1. cp .env.sample .env.local
 2. Follow the instructions in the .env.local file
 3. Run `npm run dev`
 4. Run `ngrok http 3000`
-5. Run `npx auth secret` to update the `AUTH_SECRET` in the .env.local file
-6. Add your domain to the `allowedDevOrigins` in the next.config.ts file.
-7. [For Testing] If you're using a proxy like ngrok, you need to update the `AUTH_URL` in the .env.local file to your ngrok url.
-8. Continue to developer.worldcoin.org and make sure your app is connected to the right ngrok url
-9. [Optional] For Verify and Send Transaction to work you need to do some more setup in the dev portal. The steps are outlined in the respective component files.
+5. Set `AUTH_SECRET` in the `.env.local` file to a secure random value, for example with `openssl rand -base64 32`.
+6. [For Testing] If you're using a proxy like ngrok, update `AUTH_URL` in the `.env.local` file to your ngrok URL.
+7. Continue to developer.worldcoin.org and make sure your app is connected to the right ngrok url
+8. [Optional] For Verify and Send Transaction to work you need to do some more setup in the dev portal. The steps are outlined in the respective component files.
 
 ## Authentication
 

--- a/demo/next-15-template/eslint.config.mjs
+++ b/demo/next-15-template/eslint.config.mjs
@@ -14,7 +14,6 @@ const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
     settings: { react: { version: 'detect' } },
-    plugins: { react },
     rules: {
       ...react.configs.recommended.rules,
       ...react.configs['jsx-runtime'].rules,

--- a/demo/next-15-template/next.config.ts
+++ b/demo/next-15-template/next.config.ts
@@ -1,10 +1,13 @@
 import type { NextConfig } from 'next';
 
+const authUrl = process.env.AUTH_URL;
+const allowedDevOrigins = authUrl ? [new URL(authUrl).host] : [];
+
 const nextConfig: NextConfig = {
   images: {
     domains: ['static.usernames.app-backend.toolsforhumanity.com'],
   },
-  allowedDevOrigins: ['*'], // Add your dev origin here
+  allowedDevOrigins,
   reactStrictMode: false,
 };
 

--- a/demo/next-15-template/package.json
+++ b/demo/next-15-template/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@worldcoin/mini-apps-ui-kit-react": "^1.0.2",
-    "@worldcoin/idkit": "^4.0.11",
-    "@worldcoin/minikit-js": "workspace:*",
-    "@worldcoin/minikit-react": "workspace:*",
+    "@worldcoin/idkit": "^4.1.2",
+    "@worldcoin/minikit-js": "^2.0.3",
+    "@worldcoin/minikit-react": "^2.0.3",
     "clsx": "^2.1.1",
     "iconoir-react": "^7.11.0",
     "next": "^15.2.8",

--- a/demo/next-15-template/src/app/api/rp-signature/route.ts
+++ b/demo/next-15-template/src/app/api/rp-signature/route.ts
@@ -1,4 +1,4 @@
-import { signRequest } from '@worldcoin/idkit';
+import { signRequest } from '@worldcoin/idkit/signing';
 import { NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
@@ -15,7 +15,7 @@ export async function POST(req: Request) {
   }
 
   const { action } = await req.json();
-  const sig = signRequest(action, SIGNING_KEY);
+  const sig = signRequest({ action, signingKeyHex: SIGNING_KEY });
 
   return NextResponse.json({
     rp_id: RP_ID,

--- a/demo/next-15-template/src/auth/index.ts
+++ b/demo/next-15-template/src/auth/index.ts
@@ -25,7 +25,8 @@ declare module 'next-auth' {
 // For more information on each option (and a full list of options) go to
 // https://authjs.dev/getting-started/authentication/credentials
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: process.env.AUTH_SECRET,
+  trustHost: process.env.AUTH_TRUST_HOST === 'true',
   session: { strategy: 'jwt' },
   providers: [
     Credentials({

--- a/demo/next-15-template/src/components/Transaction/index.tsx
+++ b/demo/next-15-template/src/components/Transaction/index.tsx
@@ -3,8 +3,8 @@
 import TestContractABI from '@/abi/TestContract.json';
 import { Button, LiveFeedback } from '@worldcoin/mini-apps-ui-kit-react';
 import { MiniKit } from '@worldcoin/minikit-js';
-import { useUserOperationReceipt } from '@worldcoin/minikit-react';
-import { useState } from 'react';
+import { useWaitForUserOperationReceipt } from '@worldcoin/minikit-react';
+import { useEffect, useState } from 'react';
 import { createPublicClient, encodeFunctionData, http } from 'viem';
 import { worldchain } from 'viem/chains';
 
@@ -26,6 +26,7 @@ export const Transaction = () => {
   const [whichButton, setWhichButton] = useState<'getToken' | 'transferToken'>(
     'getToken',
   );
+  const [userOpHash, setUserOpHash] = useState('');
 
   // Feel free to use your own RPC provider for better performance
   const client = createPublicClient({
@@ -33,7 +34,25 @@ export const Transaction = () => {
     transport: http('https://worldchain-mainnet.g.alchemy.com/public'),
   });
 
-  const { poll, isLoading } = useUserOperationReceipt({ client });
+  const { isLoading, isSuccess, isError } = useWaitForUserOperationReceipt({
+    client,
+    userOpHash,
+  });
+
+  useEffect(() => {
+    if (isSuccess) {
+      console.log('Transaction confirmed!');
+      setButtonState('success');
+      setUserOpHash('');
+      setTimeout(() => setButtonState(undefined), 3000);
+    }
+
+    if (isError) {
+      setButtonState('failed');
+      setUserOpHash('');
+      setTimeout(() => setButtonState(undefined), 3000);
+    }
+  }, [isError, isSuccess]);
 
   // This is a basic transaction call to mint a token
   const onClickGetToken = async () => {
@@ -60,10 +79,11 @@ export const Transaction = () => {
         result.data.userOpHash,
       );
 
-      await poll(result.data.userOpHash);
-      console.log('Transaction confirmed!');
-      setButtonState('success');
-      setTimeout(() => setButtonState(undefined), 3000);
+      if (!result.data.userOpHash) {
+        throw new Error('No userOpHash returned');
+      }
+
+      setUserOpHash(result.data.userOpHash);
     } catch (err) {
       console.error('Error:', err);
       setButtonState('failed');
@@ -99,10 +119,11 @@ export const Transaction = () => {
         result.data.userOpHash,
       );
 
-      await poll(result.data.userOpHash);
-      console.log('Transaction confirmed!');
-      setButtonState('success');
-      setTimeout(() => setButtonState(undefined), 3000);
+      if (!result.data.userOpHash) {
+        throw new Error('No userOpHash returned');
+      }
+
+      setUserOpHash(result.data.userOpHash);
     } catch (err) {
       console.error('Error:', err);
       setButtonState('failed');

--- a/demo/with-next/app/api/rp-signature/route.ts
+++ b/demo/with-next/app/api/rp-signature/route.ts
@@ -1,4 +1,4 @@
-import { signRequest } from '@worldcoin/idkit';
+import { signRequest } from '@worldcoin/idkit/signing';
 import { NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
   }
 
   const { action } = await req.json();
-  const sig = signRequest(action, SIGNING_KEY);
+  const sig = signRequest({ action, signingKeyHex: SIGNING_KEY });
 
   return NextResponse.json({
     rp_id: RP_ID,

--- a/demo/with-next/package.json
+++ b/demo/with-next/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-query": "^5.62.8",
     "@uniswap/permit2-sdk": "^1.4.0",
     "@wagmi/core": "^3.3.3",
-    "@worldcoin/idkit": "^4.0.10",
+    "@worldcoin/idkit": "^4.1.2",
     "@worldcoin/minikit-js": "workspace:*",
     "@worldcoin/minikit-react": "workspace:*",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,17 +32,17 @@ importers:
   demo/next-15-template:
     dependencies:
       '@worldcoin/idkit':
-        specifier: ^4.0.11
-        version: 4.0.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^4.1.2
+        version: 4.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@worldcoin/mini-apps-ui-kit-react':
         specifier: ^1.0.2
         version: 1.0.2(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.4)
       '@worldcoin/minikit-js':
-        specifier: workspace:*
-        version: link:../../packages/core
+        specifier: ^2.0.3
+        version: 2.0.3(qd32ftqwhjhk74hagfk6l6zzui)
       '@worldcoin/minikit-react':
-        specifier: workspace:*
-        version: link:../../packages/react
+        specifier: ^2.0.3
+        version: 2.0.3(qd32ftqwhjhk74hagfk6l6zzui)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -114,8 +114,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3(@tanstack/query-core@5.90.20)(@types/react@19.1.1)(ox@0.12.1(typescript@5.5.4)(zod@3.25.76))(react@19.1.0)(typescript@5.5.4)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.45.3(bufferutil@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@worldcoin/idkit':
-        specifier: ^4.0.10
-        version: 4.0.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^4.1.2
+        version: 4.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@worldcoin/minikit-js':
         specifier: workspace:*
         version: link:../../packages/core
@@ -2489,24 +2489,15 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
-  '@worldcoin/idkit-core@4.0.15':
-    resolution: {integrity: sha512-FlA+cBaioqXx0I2FhKbYhfIgErU70RwupjvYr8cM5GVIxbEkjkA9kwZfmfLa7cYzqWiUVQnMpbOV94eK+7l1aA==}
+  '@worldcoin/idkit-core@4.1.2':
+    resolution: {integrity: sha512-5NNjl4RL5sazcsfGxivSvYmXfcu3XZAHsjCr+98AwhU6mVOBILq21cn3zyFD/9sLU7NNr61SRZUS1mhx3knvKw==}
 
-  '@worldcoin/idkit-core@4.0.16':
-    resolution: {integrity: sha512-slcaXhP+cF/gxWQiV7ncVjXYuyoiIii2xyeweErIeLZpIJWuUpVypSxlW6S5aYHdzi1yCHt0nkIrEKSgIj9HrQ==}
-
-  '@worldcoin/idkit-server@1.0.0':
-    resolution: {integrity: sha512-ZCyXJFexxLjPtG7lxTntf6oiwF0pzoUIsVFIAAgFyXav5KmUnVlrvVoeGrgpiDFRznH2B4/Iv5xv+SkEHxOdXQ==}
+  '@worldcoin/idkit-server@1.1.1':
+    resolution: {integrity: sha512-iO4Kd3QBLzJak3BPz5eIzRjW0kT8Px5c3LbNzvCKMnczLvVSKoWqdvGiJlkK8Dp29KstNI62iv4ak0z8nzui/Q==}
     engines: {node: '>=18'}
 
-  '@worldcoin/idkit@4.0.10':
-    resolution: {integrity: sha512-oj2aR65iD82D2B2VZIs2MoX2rdHuApwSSRa12Tu66hKyj5wZfMzcIEgaHXzOU55f9Uk2TO5a1Ns8Ge5QO6EbFQ==}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  '@worldcoin/idkit@4.0.11':
-    resolution: {integrity: sha512-oAmjTdCgNX3JVQHz4cZXHRKsDuSlmzcokJPAQ4pL8HWzCYLovT5a/D5MkVW8o95+dpnwgIogvsfjWg/d1LyvWg==}
+  '@worldcoin/idkit@4.1.2':
+    resolution: {integrity: sha512-0ys1C4y/xpT2/NxqbvrpWcfhDGB+hkAkkJgmxcCDXyCrxTNDoVeJn74kBxmoeDBQ+6Aj89d3n8gTV6My8KZPBw==}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
@@ -2520,6 +2511,28 @@ packages:
     peerDependenciesMeta:
       tailwindcss:
         optional: true
+
+  '@worldcoin/minikit-js@2.0.3':
+    resolution: {integrity: sha512-41rhB59/MOWpAihcCidMijYmzlht5BDPTBQwRRDMhX65rC4Ac2+qEkajDgCR1xW/YWZm122Z8muJzr1pODDq1A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      react: ^17 || ^18 || ^19
+      siwe: ^3.0.0
+      viem: ^2.21.0
+      wagmi: 3.4.3
+    peerDependenciesMeta:
+      siwe:
+        optional: true
+      viem:
+        optional: true
+      wagmi:
+        optional: true
+
+  '@worldcoin/minikit-react@2.0.3':
+    resolution: {integrity: sha512-m6eoSFHltfHzQQcWWguOLbierLCyf8Kmg7WZ5I/hN8IaayVmN+HQwEm0DqKTkzdcnug5sDoQxB5avOFuwLoiTA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      react: ^18 || ^19
 
   abitype@1.0.6:
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
@@ -10118,31 +10131,19 @@ snapshots:
       tslib: 1.14.1
     optional: true
 
-  '@worldcoin/idkit-core@4.0.15':
+  '@worldcoin/idkit-core@4.1.2':
     dependencies:
       '@noble/hashes': 1.8.0
-      '@worldcoin/idkit-server': 1.0.0
+      '@worldcoin/idkit-server': 1.1.1
 
-  '@worldcoin/idkit-core@4.0.16':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      '@worldcoin/idkit-server': 1.0.0
-
-  '@worldcoin/idkit-server@1.0.0':
+  '@worldcoin/idkit-server@1.1.1':
     dependencies:
       '@noble/hashes': 1.8.0
       '@noble/secp256k1': 2.3.0
 
-  '@worldcoin/idkit@4.0.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@worldcoin/idkit@4.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@worldcoin/idkit-core': 4.0.15
-      qrcode: 1.5.4
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  '@worldcoin/idkit@4.0.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@worldcoin/idkit-core': 4.0.16
+      '@worldcoin/idkit-core': 4.1.2
       qrcode: 1.5.4
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -10174,6 +10175,31 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  '@worldcoin/minikit-js@2.0.3(qd32ftqwhjhk74hagfk6l6zzui)':
+    dependencies:
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.3.6)
+      react: 19.1.0
+    optionalDependencies:
+      siwe: 3.0.0(ethers@6.13.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      viem: 2.45.3(bufferutil@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.3.6)
+      wagmi: 3.4.3(@coinbase/wallet-sdk@4.3.6(@types/react@19.1.1)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.5.4)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.6))(@gemini-wallet/core@0.3.2(viem@2.45.3(bufferutil@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.3.6)))(@metamask/sdk@0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.3.6))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.3.6))(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@19.1.0))(@types/react@19.1.1)(@walletconnect/ethereum-provider@2.21.1(@types/react@19.1.1)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.3.6))(ox@0.12.1(typescript@5.5.4)(zod@4.3.6))(porto@0.2.35)(react@19.1.0)(typescript@5.5.4)(viem@2.45.3(bufferutil@4.1.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@4.3.6))
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
+  '@worldcoin/minikit-react@2.0.3(qd32ftqwhjhk74hagfk6l6zzui)':
+    dependencies:
+      '@worldcoin/minikit-js': 2.0.3(qd32ftqwhjhk74hagfk6l6zzui)
+      abitype: 1.2.3(typescript@5.5.4)(zod@4.3.6)
+      react: 19.1.0
+      turbo: 2.8.20
+    transitivePeerDependencies:
+      - siwe
+      - typescript
+      - viem
+      - wagmi
+      - zod
 
   abitype@1.0.6(typescript@5.5.4)(zod@3.25.76):
     optionalDependencies:


### PR DESCRIPTION
* Bump to latest idkit version
* Keep `with-next` example with local workspace packages
* Use hardcoded minikit versions in `next-15` example which is used by the `@worldcoin/create-mini-app` template generator