### PR TITLE
fix: correct demo heading to MiniKit V2

### DIFF
--- a/demo/with-next/components/ClientContent/Nav.tsx
+++ b/demo/with-next/components/ClientContent/Nav.tsx
@@ -7,7 +7,7 @@ export const Nav = () => {
 
   return (
     <header className="flex justify-between gap-x-2">
-      <h1 className="text-2xl font-bold">MiniKit V1</h1>
+      <h1 className="text-2xl font-bold">MiniKit V2</h1>
 
       {/* <button
         onClick={user?.name ? () => signOut() : () => signIn('google')}


### PR DESCRIPTION
## What

The `next` demo (`demo/with-next`) runs the **v2** SDK (`@worldcoin/minikit-js` 2.0.x), but the nav heading still reads **"MiniKit V1"** (`Nav.tsx:10`). This updates it to **"MiniKit V2"** so the deployed staging demo reflects reality.

## Why

Purely cosmetic/labeling — the "V1" string is leftover and misleading (the demo uses the v2 direct-async API, not the old `MiniKit.commands*` API). Noticed while comparing v1 vs v2 demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)