### PR TITLE
feat(core): add client_name/client_version to WorldApp payload

### DIFF
--- a/.changeset/miniapp-client-identity.md
+++ b/.changeset/miniapp-client-identity.md
@@ -1,0 +1,5 @@
+---
+'@worldcoin/minikit-js': minor
+---
+
+Add optional `client_name` (`'world_app' | 'world_id_app'`) and `client_version` to the `window.WorldApp` payload and expose them on `MiniKit.deviceProperties` as `clientName` / `clientVersion`. This lets mini apps and MiniKit branch on which host app is running them instead of overloading `world_app_version`. Both fields are optional and absent on older hosts; callers must fall back to `world_app_version`.

--- a/demo/with-next/global.d.ts
+++ b/demo/with-next/global.d.ts
@@ -16,6 +16,8 @@ interface Window {
   WorldApp?: {
     world_app_version: number;
     device_os: 'ios' | 'android';
+    client_name?: 'world_app' | 'world_id_app';
+    client_version?: string;
 
     supported_commands: Array<{
       name: import('@worldcoin/minikit-js').Command;

--- a/packages/core/src/global.d.ts
+++ b/packages/core/src/global.d.ts
@@ -17,6 +17,12 @@ interface Window {
   WorldApp?: {
     world_app_version: number;
     device_os: 'ios' | 'android';
+    // Explicit client identity so mini apps / MiniKit can branch on which app is
+    // hosting them instead of overloading world_app_version. Optional for
+    // backward-compat: older hosts omit these, callers must fall back to
+    // world_app_version. See UGROWTH-1032.
+    client_name?: 'world_app' | 'world_id_app';
+    client_version?: string;
     is_optional_analytics: boolean;
     supported_commands: Array<{
       name: import('./commands/types').Command;

--- a/packages/core/src/minikit.ts
+++ b/packages/core/src/minikit.ts
@@ -572,6 +572,9 @@ export class MiniKit {
     this._deviceProperties.safeAreaInsets = worldApp.safe_area_insets;
     this._deviceProperties.deviceOS = worldApp.device_os;
     this._deviceProperties.worldAppVersion = worldApp.world_app_version;
+    // Optional on older hosts; left undefined when the host does not emit them.
+    this._deviceProperties.clientName = worldApp.client_name;
+    this._deviceProperties.clientVersion = worldApp.client_version;
 
     // Set launch location
     this._location = mapWorldAppLaunchLocation(worldApp.location);

--- a/packages/core/src/tests/init-from-worldapp.test.ts
+++ b/packages/core/src/tests/init-from-worldapp.test.ts
@@ -12,6 +12,8 @@ function makeWorldApp(
   return {
     world_app_version: 4001000,
     device_os: 'ios',
+    client_name: 'world_app',
+    client_version: '4.0.1',
     is_optional_analytics: true,
     supported_commands: [
       { name: 'verify' as any, supported_versions: [1] },
@@ -77,6 +79,8 @@ describe('MiniKit.install – initFromWorldApp mapping', () => {
 
     expect(MiniKit.deviceProperties.worldAppVersion).toBe(4001000);
     expect(MiniKit.deviceProperties.deviceOS).toBe('ios');
+    expect(MiniKit.deviceProperties.clientName).toBe('world_app');
+    expect(MiniKit.deviceProperties.clientVersion).toBe('4.0.1');
     expect(MiniKit.deviceProperties.safeAreaInsets).toEqual({
       top: 47,
       right: 0,
@@ -113,6 +117,33 @@ describe('MiniKit.install – initFromWorldApp mapping', () => {
     expect(MiniKit.user.preferredCurrency).toBeUndefined();
     expect(MiniKit.user.pendingNotifications).toBeUndefined();
     expect(MiniKit.location).toBeNull();
+  });
+
+  it('leaves client identity undefined on legacy hosts that omit it', () => {
+    (global as any).window.WorldApp = makeWorldApp({
+      client_name: undefined,
+      client_version: undefined,
+    });
+
+    const result = MiniKit.install('app_test');
+    expect(result.success).toBe(true);
+
+    expect(MiniKit.deviceProperties.clientName).toBeUndefined();
+    expect(MiniKit.deviceProperties.clientVersion).toBeUndefined();
+    // world_app_version stays available as the fallback signal.
+    expect(MiniKit.deviceProperties.worldAppVersion).toBe(4001000);
+  });
+
+  it('maps World ID app client identity', () => {
+    (global as any).window.WorldApp = makeWorldApp({
+      client_name: 'world_id_app',
+      client_version: '1.4.0',
+    });
+
+    MiniKit.install('app_test');
+
+    expect(MiniKit.deviceProperties.clientName).toBe('world_id_app');
+    expect(MiniKit.deviceProperties.clientVersion).toBe('1.4.0');
   });
 
   it('re-install clears stale user state from previous install', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,10 @@ export type DeviceProperties = {
   };
   deviceOS?: string;
   worldAppVersion?: number;
+  // Explicit host identity. Prefer these over worldAppVersion when present;
+  // they are absent on older hosts that only emit world_app_version.
+  clientName?: 'world_app' | 'world_id_app';
+  clientVersion?: string;
 };
 
 export type UserNameService = {


### PR DESCRIPTION
## Summary

Adds explicit host identity to the `window.WorldApp` init payload so mini apps and MiniKit can tell **World App** from the **World ID app** instead of overloading `world_app_version`.

Today the World ID app (iOS + Android) spoofs `world_app_version` to `4_002_700` so it clears MiniKit's wallet-auth version gate (`worldAppVersion <= 2087900` in `commands/wallet-auth/index.ts`). That means a mini app literally cannot distinguish the two apps and reads a fabricated version on WIDA.

## Changes
- `packages/core/src/global.d.ts` + `demo/with-next/global.d.ts`: add optional `client_name: 'world_app' | 'world_id_app'` and `client_version: string` to the `WorldApp` type.
- `packages/core/src/types.ts`: add `clientName` / `clientVersion` to `DeviceProperties`.
- `packages/core/src/minikit.ts` (`initFromWorldApp`): map both into `MiniKit.deviceProperties`.
- Tests: assert mapping for World App + World ID app, and that fields stay `undefined` on legacy hosts that omit them.
- Changeset (minor).

## Backward compatibility
Both fields are **optional**. Older hosts emit neither, so consumers must keep falling back to `world_app_version`. This PR is the contract only — it does **not** change any gating yet.

## Native emitters
- iOS: worldcoin/world-app-ios#6985
- Android: worldcoin/wld-android#8001

## Follow-up
Once the emitters ship and a minimum MiniKit version is broadly deployed, migrate the wallet-auth gate to `client_name` and retire the `4_002_700` spoof.

Refs UGROWTH-1032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)