### PR TITLE
fix: support soft and rigid haptic styles

### DIFF
--- a/.changeset/tidy-haptics.md
+++ b/.changeset/tidy-haptics.md
@@ -1,0 +1,5 @@
+---
+'@worldcoin/minikit-js': patch
+---
+
+Allow the documented `soft` and `rigid` styles for impact haptic feedback.

--- a/demo/with-next/components/ClientContent/SendHaptic.tsx
+++ b/demo/with-next/components/ClientContent/SendHaptic.tsx
@@ -24,6 +24,8 @@ const allPossibleHaptics: SendHapticFeedbackInput[] = [
   { hapticsType: 'impact', style: 'heavy' },
   { hapticsType: 'impact', style: 'light' },
   { hapticsType: 'impact', style: 'medium' },
+  { hapticsType: 'impact', style: 'soft' },
+  { hapticsType: 'impact', style: 'rigid' },
   { hapticsType: 'notification', style: 'error' },
   { hapticsType: 'notification', style: 'success' },
   { hapticsType: 'notification', style: 'warning' },

--- a/packages/core/src/commands/send-haptic-feedback/types.ts
+++ b/packages/core/src/commands/send-haptic-feedback/types.ts
@@ -15,7 +15,7 @@ type SendHapticFeedbackParams =
     }
   | {
       hapticsType: 'impact';
-      style: 'light' | 'medium' | 'heavy';
+      style: 'light' | 'medium' | 'heavy' | 'soft' | 'rigid';
     };
 
 /** @deprecated Use {@link MiniKitSendHapticFeedbackOptions} instead */

--- a/packages/core/src/tests/send-haptic-feedback.test.ts
+++ b/packages/core/src/tests/send-haptic-feedback.test.ts
@@ -1,0 +1,15 @@
+import type { SendHapticFeedbackInput } from '../commands/send-haptic-feedback';
+
+describe('SendHapticFeedbackInput', () => {
+  it.each(['soft', 'rigid'] as const)(
+    'accepts the %s impact style',
+    (style) => {
+      const input: SendHapticFeedbackInput = {
+        hapticsType: 'impact',
+        style,
+      };
+
+      expect(input.style).toBe(style);
+    },
+  );
+});


### PR DESCRIPTION
## Changes

- add `soft` and `rigid` to impact haptic feedback input types
- include both styles in the demo's exhaustive haptic list
- add a regression test and patch changeset

## Why

The public Mini Apps documentation lists these impact styles, but the SDK's TypeScript union rejected them.

## Impact

TypeScript consumers can use the documented World App haptic styles without casts. Runtime payload handling already forwards impact styles unchanged.

Closes #251.

## Checks

- `corepack pnpm --filter @worldcoin/minikit-js lint`
- `corepack pnpm --filter @worldcoin/minikit-js test -- --runInBand` (56 passing)
- `corepack pnpm --filter @worldcoin/minikit-js type-check`
- `corepack pnpm --filter @worldcoin/minikit-js build`
- staged diff leakage scan

## Disclosure

This contribution was prepared with AI assistance and reviewed against the public repository and public issue #251 only. No private code, production data, or internal implementation details were used.