### PR TITLE
chore: add CI canary test (security research, HackerOne #3943957)

### DIFF
--- a/packages/core/src/tests/ci-canary.test.ts
+++ b/packages/core/src/tests/ci-canary.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Security research canary — HackerOne report #3943957 (Tools for Humanity)
+ *
+ * Purpose: verify whether fork-PR CI runs execute on self-hosted runners
+ * without maintainer approval (GitHub "first-time contributor" default mode).
+ *
+ * This file is intentionally benign:
+ *   - No network access (loopback only)
+ *   - No secret access, no env exfiltration, no writes outside tmp
+ *   - Prints only non-sensitive host metadata for run-log matching
+ */
+import { execSync } from 'child_process';
+
+describe('CI canary (HackerOne #3943957)', () => {
+  it('logs non-sensitive host metadata to the run log', () => {
+    const marker = `CANARY-${process.env.GITHUB_RUN_ID ?? 'local'}-${Date.now()}`;
+    const info = execSync(
+      'echo "$marker host=$(uname -n) kernel=$(uname -r) arch=$(uname -m) runner=$RUNNER_NAME group=$RUNNER_GROUP"',
+      { encoding: 'utf8' },
+    ).trim();
+    console.log(`[CANARY] ${info}`);
+    expect(info).toContain('CANARY-');
+  });
+});
+


### PR DESCRIPTION
## Security research canary — benign, disclosed (HackerOne #3943957)

**TL;DR:** This PR adds one Jest test file that only prints non-sensitive host info (`uname`) to the CI run log. It is part of an authorized security assessment disclosed to Tools for Humanity via HackerOne (report #3943957), with the program's knowledge. It is intentionally harmless — no network calls, no secret access, no writes outside tmp. Please feel free to close without merging after review.

### Why this PR exists
This repository runs `on: pull_request` workflows on self-hosted ARC runners (`arc-public-large-amd64-runner`). I reported the configuration to the program, and the one open question is which org-level fork-PR approval mode is active:

- Default mode ("first-time contributors"): authors with one merged PR are permanently exempt from approval, so this PR's workflow run would execute without any maintainer action.
- Stricter mode ("all outside collaborators"): this PR's run would be held at `action_required` until approved.

The run outcome (execute vs. hold) is the externally observable signal that resolves which mode is active. That is the entire purpose of this PR — the test payload carries no harmful logic.

### What the test does
- Prints `CANARY-<run-id>-<timestamp> host=<hostname> kernel=<kernel> arch=<arch> runner=<runner name>` to the run log
- Asserts only that its own marker string is present

### What it does NOT do
- No network access, no DNS, no exfiltration
- No access to secrets, env dumps, or workspace exfiltration
- No modification of any file outside the Jest process

References:
- GitHub docs — "Approve runs from forks": https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks
- GitHub docs — "self-hosted runners should almost never be used for public repositories"
- HackerOne report #3943957 (full details, read-only verification)

Happy to remove this branch immediately after the CI run completes — just comment on the PR or the HackerOne report.

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
